### PR TITLE
Fixed Game dependencies syntax in modinfo.json

### DIFF
--- a/scoreboard_new/modinfo.json
+++ b/scoreboard_new/modinfo.json
@@ -6,9 +6,8 @@
       "MadGnome",
       "codeAtorium"
     ],
-    "description": "A set of leaderstats boards for servers.",
-    "version": "1.1.4",
+    "description": "A set of leaderstats boards for servers.",    
     "dependencies": {
-        "game": "1.19.*"
+        "game": "1.19.0"
     }
 }


### PR DESCRIPTION
The game was printing a warning in the log about improper version dependencies syntax (1.19.*). The proper way to write this is to remove the * character and replace it with the lowest supported minor version number (in this case, 0).